### PR TITLE
msm8226.mk: call inherit if exist only

### DIFF
--- a/msm8226.mk
+++ b/msm8226.mk
@@ -16,7 +16,7 @@
 
 $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
 
-$(call inherit-product, vendor/motorola/msm8226-common/msm8226-common-vendor.mk)
+$(call inherit-product-if-exist, vendor/motorola/msm8226-common/msm8226-common-vendor.mk)
 
 # Overlay
 DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay


### PR DESCRIPTION
this way the build process can continue without the need for proprietary.
